### PR TITLE
Fix - Wrong Jwt credentials being accepted.

### DIFF
--- a/src/Guards/JwtGuard.php
+++ b/src/Guards/JwtGuard.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
  * @contact  eric@zhu.email
  * @license  https://github.com/hyperf-ext/auth/blob/master/LICENSE
  */
-
 namespace HyperfExt\Auth\Guards;
 
 use BadMethodCallException;
@@ -114,8 +113,7 @@ class JwtGuard implements StatelessGuardInterface
             return $this->user;
         }
 
-        if (
-            $this->jwt->getToken() and
+        if ($this->jwt->getToken() and
             ($payload = $this->jwt->check(true)) and
             $this->validateSubject() and
             ($this->user = $this->provider->retrieveById($payload['sub']))
@@ -134,7 +132,7 @@ class JwtGuard implements StatelessGuardInterface
      */
     public function userOrFail(): AuthenticatableInterface
     {
-        if (!$user = $this->user()) {
+        if (! $user = $this->user()) {
             throw new UserNotDefinedException();
         }
 
@@ -190,7 +188,7 @@ class JwtGuard implements StatelessGuardInterface
      */
     public function loginUsingId($id)
     {
-        if (!is_null($user = $this->provider->retrieveById($id))) {
+        if (! is_null($user = $this->provider->retrieveById($id))) {
             return $this->login($user);
         }
 
@@ -332,7 +330,7 @@ class JwtGuard implements StatelessGuardInterface
     {
         // If the provider doesn't have the necessary method
         // to get the underlying model name then allow.
-        if (!method_exists($this->provider, 'getModel')) {
+        if (! method_exists($this->provider, 'getModel')) {
             return true;
         }
 
@@ -346,7 +344,7 @@ class JwtGuard implements StatelessGuardInterface
      */
     protected function requireToken(): Jwt
     {
-        if (!$this->jwt->getToken()) {
+        if (! $this->jwt->getToken()) {
             throw new JwtException('Token could not be parsed from the request.');
         }
 

--- a/src/Guards/JwtGuard.php
+++ b/src/Guards/JwtGuard.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  * @contact  eric@zhu.email
  * @license  https://github.com/hyperf-ext/auth/blob/master/LICENSE
  */
+
 namespace HyperfExt\Auth\Guards;
 
 use BadMethodCallException;
@@ -113,7 +114,8 @@ class JwtGuard implements StatelessGuardInterface
             return $this->user;
         }
 
-        if ($this->jwt->getToken() and
+        if (
+            $this->jwt->getToken() and
             ($payload = $this->jwt->check(true)) and
             $this->validateSubject() and
             ($this->user = $this->provider->retrieveById($payload['sub']))
@@ -132,7 +134,7 @@ class JwtGuard implements StatelessGuardInterface
      */
     public function userOrFail(): AuthenticatableInterface
     {
-        if (! $user = $this->user()) {
+        if (!$user = $this->user()) {
             throw new UserNotDefinedException();
         }
 
@@ -188,7 +190,7 @@ class JwtGuard implements StatelessGuardInterface
      */
     public function loginUsingId($id)
     {
-        if (! is_null($user = $this->provider->retrieveById($id))) {
+        if (!is_null($user = $this->provider->retrieveById($id))) {
             return $this->login($user);
         }
 
@@ -312,7 +314,7 @@ class JwtGuard implements StatelessGuardInterface
      */
     protected function hasValidCredentials(?AuthenticatableInterface $user, array $credentials): bool
     {
-        $validated = $user !== null and $this->provider->validateCredentials($user, $credentials);
+        $validated = ($user !== null and $this->provider->validateCredentials($user, $credentials));
 
         if ($validated) {
             $this->dispatchValidatedEvent($user);
@@ -330,7 +332,7 @@ class JwtGuard implements StatelessGuardInterface
     {
         // If the provider doesn't have the necessary method
         // to get the underlying model name then allow.
-        if (! method_exists($this->provider, 'getModel')) {
+        if (!method_exists($this->provider, 'getModel')) {
             return true;
         }
 
@@ -344,7 +346,7 @@ class JwtGuard implements StatelessGuardInterface
      */
     protected function requireToken(): Jwt
     {
-        if (! $this->jwt->getToken()) {
+        if (!$this->jwt->getToken()) {
             throw new JwtException('Token could not be parsed from the request.');
         }
 

--- a/tests/AuthGuardTest.php
+++ b/tests/AuthGuardTest.php
@@ -8,10 +8,12 @@ declare(strict_types=1);
  * @contact  eric@zhu.email
  * @license  https://github.com/hyperf-ext/auth/blob/master/LICENSE
  */
+
 namespace HyperfTest;
 
 use Hyperf\Contract\SessionInterface;
 use Hyperf\HttpMessage\Cookie\Cookie;
+use HyperfExt\Cookie\Contract\CookieJarInterface;
 use Hyperf\HttpMessage\Uri\Uri;
 use Hyperf\HttpServer\Request;
 use Hyperf\Utils\Context;
@@ -559,17 +561,15 @@ class AuthGuardTest extends TestCase
             new Request(),
             m::mock(SessionInterface::class),
             m::mock(EventDispatcherInterface::class),
-            m::mock(CookieJar::class),
+            m::mock(CookieJarInterface::class),
             m::mock(UserProviderInterface::class),
-            [
-                'name' => 'foo',
-            ],
+            'foo',
         ];
     }
 
     protected function getCookieJar()
     {
         return new CookieJar();
-//        return new CookieJar(Request::create('/foo', 'GET'), m::mock(Encrypter::class), ['domain' => 'foo.com', 'path' => '/', 'secure' => false, 'httpOnly' => false]);
+        //        return new CookieJar(Request::create('/foo', 'GET'), m::mock(Encrypter::class), ['domain' => 'foo.com', 'path' => '/', 'secure' => false, 'httpOnly' => false]);
     }
 }

--- a/tests/AuthJwtGuardTest.php
+++ b/tests/AuthJwtGuardTest.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+/**
+ * This file is part of hyperf-ext/auth.
+ *
+ * @link     https://github.com/hyperf-ext/auth
+ * @contact  eric@zhu.email
+ * @license  https://github.com/hyperf-ext/auth/blob/master/LICENSE
+ */
+
+namespace HyperfTest;
+
+use Hyperf\HttpServer\Request;
+use Hyperf\Utils\Context;
+use HyperfExt\Auth\Contracts\UserProviderInterface;
+use HyperfExt\Auth\Guards\JwtGuard;
+use HyperfExt\Auth\Guards\TokenGuard;
+use Mockery as m;
+use PHPUnit\Framework\TestCase;
+use Psr\Container\ContainerInterface;
+use HyperfExt\Jwt\JwtFactory;
+use Psr\Http\Message\ServerRequestInterface;
+use Psr\EventDispatcher\EventDispatcherInterface;
+
+/**
+ * @internal
+ * @coversNothing
+ */
+class AuthJwtGuardTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        m::close();
+    }
+
+    public function testFailValidateCredentials()
+    {
+        $provider = m::mock(UserProviderInterface::class);
+        $container = m::mock(ContainerInterface::class);
+        $jwtFactory = m::mock(JwtFactory::class);
+        $jwt = m::mock(Jwt::class);
+        $dispatcher = m::mock(EventDispatcherInterface::class);
+
+        $user = new AuthTokenGuardTestUser();
+        $user->id = 1;
+        $user->password = 'hash';
+        $request = $this->createRequest(['id' => '1', 'password' => '123456']);
+        $provider->shouldReceive('retrieveByCredentials')->once()->with(['id' => '1', 'password' => '123456'])->andReturn($user);
+        $provider->shouldReceive('validateCredentials')->once()->andReturn(false);
+        $jwt->shouldReceive('fromUser')->andReturn('token');
+        $jwt->shouldReceive('setToken');
+        $jwtFactory->shouldReceive('make')->once()->andReturn($jwt);
+        $dispatcher->shouldReceive('dispatch');
+
+        $guard = new JwtGuard($container, $request, $jwtFactory, $dispatcher, $provider, 'foo');
+
+        $result = $guard->attempt(['id' => '1', 'password' => '123456']);
+
+        $this->assertEquals(false, $result);
+    }
+
+    public function testSuccessValidateCredentials()
+    {
+        $provider = m::mock(UserProviderInterface::class);
+        $container = m::mock(ContainerInterface::class);
+        $jwtFactory = m::mock(JwtFactory::class);
+        $jwt = m::mock(Jwt::class);
+        $dispatcher = m::mock(EventDispatcherInterface::class);
+
+        $user = new AuthTokenGuardTestUser();
+        $user->id = 1;
+        $user->password = 'hash';
+        $request = $this->createRequest(['id' => '1', 'password' => '123456']);
+        $provider->shouldReceive('retrieveByCredentials')->once()->with(['id' => '1', 'password' => '123456'])->andReturn($user);
+        $provider->shouldReceive('validateCredentials')->once()->andReturn(true);
+        $jwt->shouldReceive('fromUser')->once()->andReturn('token');
+        $jwt->shouldReceive('setToken')->once();
+        $jwtFactory->shouldReceive('make')->once()->andReturn($jwt);
+        $dispatcher->shouldReceive('dispatch');
+
+        $guard = new JwtGuard($container, $request, $jwtFactory, $dispatcher, $provider, 'foo');
+
+        $result = $guard->attempt(['id' => '1', 'password' => '123456']);
+
+        $this->assertEquals('token', $result);
+    }
+
+    protected function createRequest(array $params = [], array $headers = [])
+    {
+        $request = new \Hyperf\HttpMessage\Server\Request('GET', '/');
+        Context::set(ServerRequestInterface::class, $request->withQueryParams($params)->withHeaders($headers));
+        return new Request();
+    }
+}
+
+class AuthJwtGuardTestUser extends User
+{
+    public $id;
+
+    public function getAuthIdentifier()
+    {
+        return $this->id;
+    }
+}

--- a/tests/AuthTokenGuardTest.php
+++ b/tests/AuthTokenGuardTest.php
@@ -8,6 +8,7 @@ declare(strict_types=1);
  * @contact  eric@zhu.email
  * @license  https://github.com/hyperf-ext/auth/blob/master/LICENSE
  */
+
 namespace HyperfTest;
 
 use Hyperf\HttpServer\Request;
@@ -37,7 +38,7 @@ class AuthTokenGuardTest extends TestCase
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'foo'])->andReturn($user);
         $request = $this->createRequest(['api_token' => 'foo']);
 
-        $guard = new TokenGuard($request, $provider);
+        $guard = new TokenGuard($request, $provider, 'foo');
 
         $user = $guard->user();
 
@@ -55,7 +56,7 @@ class AuthTokenGuardTest extends TestCase
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => hash('sha256', 'foo')])->andReturn($user);
         $request = $this->createRequest(['api_token' => 'foo']);
 
-        $guard = new TokenGuard($request, $provider, [
+        $guard = new TokenGuard($request, $provider, 'foo', [
             'input_key' => 'api_token',
             'storage_key' => 'api_token',
             'hash' => true,
@@ -75,7 +76,7 @@ class AuthTokenGuardTest extends TestCase
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'foo'])->andReturn(new AuthTokenGuardTestUser());
         $request = $this->createRequest([], ['Authorization' => 'Basic ' . base64_encode('foo:foo')]);
 
-        $guard = new TokenGuard($request, $provider);
+        $guard = new TokenGuard($request, $provider, 'foo');
 
         $user = $guard->user();
 
@@ -88,7 +89,7 @@ class AuthTokenGuardTest extends TestCase
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'foo'])->andReturn(new AuthTokenGuardTestUser());
         $request = $this->createRequest([], ['Authorization' => 'Bearer foo']);
 
-        $guard = new TokenGuard($request, $provider);
+        $guard = new TokenGuard($request, $provider, 'foo');
 
         $user = $guard->user();
 
@@ -103,7 +104,7 @@ class AuthTokenGuardTest extends TestCase
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'foo'])->andReturn($user);
         $request = $this->createRequest(['api_token' => 'foo']);
 
-        $guard = new TokenGuard($request, $provider);
+        $guard = new TokenGuard($request, $provider, 'foo');
 
         $this->assertTrue($guard->validate(['api_token' => 'foo']));
     }
@@ -114,7 +115,7 @@ class AuthTokenGuardTest extends TestCase
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'foo'])->andReturn(null);
         $request = $this->createRequest(['api_token' => 'foo']);
 
-        $guard = new TokenGuard($request, $provider);
+        $guard = new TokenGuard($request, $provider, 'foo');
 
         $this->assertFalse($guard->validate(['api_token' => 'foo']));
     }
@@ -124,7 +125,7 @@ class AuthTokenGuardTest extends TestCase
         $provider = m::mock(UserProviderInterface::class);
         $request = $this->createRequest(['api_token' => 'foo']);
 
-        $guard = new TokenGuard($request, $provider);
+        $guard = new TokenGuard($request, $provider, 'foo');
 
         $this->assertFalse($guard->validate(['api_token' => '']));
     }
@@ -137,7 +138,7 @@ class AuthTokenGuardTest extends TestCase
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['api_token' => 'custom'])->andReturn($user);
         $request = $this->createRequest(['api_token' => 'foo']);
 
-        $guard = new TokenGuard($request, $provider);
+        $guard = new TokenGuard($request, $provider, 'foo');
         $guard->setRequest($this->createRequest(['api_token' => 'custom']));
 
         $user = $guard->user();
@@ -151,7 +152,7 @@ class AuthTokenGuardTest extends TestCase
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['custom_token_field' => 'foo'])->andReturn(new AuthTokenGuardTestUser());
         $request = $this->createRequest([], ['Authorization' => 'Bearer foo']);
 
-        $guard = new TokenGuard($request, $provider, [
+        $guard = new TokenGuard($request, $provider, 'foo', [
             'input_key' => 'custom_token_field',
             'storage_key' => 'custom_token_field',
         ]);
@@ -169,7 +170,7 @@ class AuthTokenGuardTest extends TestCase
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['custom_token_field' => 'foo'])->andReturn($user);
         $request = $this->createRequest(['custom_token_field' => 'foo']);
 
-        $guard = new TokenGuard($request, $provider, [
+        $guard = new TokenGuard($request, $provider, 'foo', [
             'input_key' => 'custom_token_field',
             'storage_key' => 'custom_token_field',
         ]);
@@ -188,7 +189,7 @@ class AuthTokenGuardTest extends TestCase
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['custom_token_field' => 'foo'])->andReturn(new AuthTokenGuardTestUser());
         $request = $this->createRequest([], ['Authorization' => 'Basic ' . base64_encode('foo:foo')]);
 
-        $guard = new TokenGuard($request, $provider, [
+        $guard = new TokenGuard($request, $provider, 'foo', [
             'input_key' => 'custom_token_field',
             'storage_key' => 'custom_token_field',
         ]);
@@ -206,7 +207,7 @@ class AuthTokenGuardTest extends TestCase
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['custom_token_field' => 'foo'])->andReturn($user);
         $request = $this->createRequest(['custom_token_field' => 'foo']);
 
-        $guard = new TokenGuard($request, $provider, [
+        $guard = new TokenGuard($request, $provider, 'foo', [
             'input_key' => 'custom_token_field',
             'storage_key' => 'custom_token_field',
         ]);
@@ -220,7 +221,7 @@ class AuthTokenGuardTest extends TestCase
         $provider->shouldReceive('retrieveByCredentials')->once()->with(['custom_token_field' => 'foo'])->andReturn(null);
         $request = $this->createRequest(['custom_token_field' => 'foo']);
 
-        $guard = new TokenGuard($request, $provider, [
+        $guard = new TokenGuard($request, $provider, 'foo', [
             'input_key' => 'custom_token_field',
             'storage_key' => 'custom_token_field',
         ]);
@@ -233,7 +234,7 @@ class AuthTokenGuardTest extends TestCase
         $provider = m::mock(UserProviderInterface::class);
         $request = $this->createRequest(['custom_token_field' => '']);
 
-        $guard = new TokenGuard($request, $provider, [
+        $guard = new TokenGuard($request, $provider, 'foo', [
             'input_key' => 'custom_token_field',
             'storage_key' => 'custom_token_field',
         ]);


### PR DESCRIPTION
Fixed the 'and' operator precedence on JwtGuard::hasValidCredentials.
The wrong precedence was considering invalid credentials as valid because the user object was not null.

Please refer to the link below:
https://stackoverflow.com/a/2803576

I also adjusted the tests that were broken and created 2 tests to validate the fix.