### PR TITLE
fix: 修复无参数值请求时，getBasicAuthorization方法$header默认值类型错误引发的异常

### DIFF
--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -93,7 +93,7 @@ class TokenGuard implements GuardInterface
     /**
      * Get the token for the current request.
      */
-    public function getTokenForRequest(): string
+    public function getTokenForRequest(): string|null
     {
         $token = $this->request->query($this->inputKey);
 

--- a/src/Guards/TokenGuard.php
+++ b/src/Guards/TokenGuard.php
@@ -162,7 +162,7 @@ class TokenGuard implements GuardInterface
      */
     protected function getBasicAuthorization(): array
     {
-        $header = $this->request->header('Authorization');
+        $header = $this->request->header('Authorization', '');
 
         if (Str::startsWith($header, 'Basic ')) {
             try {


### PR DESCRIPTION
修复无参数值请求时，getBasicAuthorization $header默认值类型错误引发的异常